### PR TITLE
Fixando Lib Bip39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Mudamos LibCrypto
 Creates and manipulates seeds and wallets for Blockchain
 =======
 
-[NPM Link](https://www.npmjs.org/package/mudamos-lib-crypto)
+[NPM Link](https://www.npmjs.org/package/mudamos-libcrypto)
 
 [![NPM Package](https://img.shields.io/npm/v/@cycle/core.svg)](https://www.npmjs.org/package/mudamos-lib-crypto)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Mudamos LibCrypto
 Creates and manipulates seeds and wallets for Blockchain
 =======
 
-[NPM Link](https://www.npmjs.org/package/mudamos-libcrypto)
+[NPM Link](https://www.npmjs.org/package/mudamos-lib-crypto)
 
 [![NPM Package](https://img.shields.io/npm/v/@cycle/core.svg)](https://www.npmjs.org/package/mudamos-lib-crypto)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mudamos-libcrypto",
   "description": "Library for encryption and creation of Wallets in Blockchain",
   "readmeFilename": "README.md",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha"
   },
@@ -24,7 +24,7 @@
     "babel-preset-es2015": "^6.18.0",
     "bigi": "^1.4.2",
     "bip32-utils": "^0.9.1",
-    "bip39": "^2.2.0",
+    "bip39": "2.2.0",
     "bitcoinjs-lib": "^2.3.0",
     "bitcoinjs-message": "^1.0.1",
     "describe": "^1.2.0",


### PR DESCRIPTION

This update fixed Bip39 Lib 

• How was it before?

We could just verify messages on our system

• What should I pay attention when reviewing this PR?

The mobile-app and mobile-api both will need to update the repositories to the libcrypto version 0.6.5

• Is this PR dangerous?

Not - but the test messages signed before probably will not be recognized in this version